### PR TITLE
Add specialized `ldiv!` handling

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -57,3 +57,7 @@ function LinearAlgebra.axpby!(α::Number, x::ComponentArray, β::Number, y::Comp
     axpby!(α, getdata(x), β, getdata(y))
     return ComponentArray(y, getaxes(y))
 end
+
+function LinearAlgebra.ldiv!(B::AbstractVecOrMat, D::Diagonal{Float64, <:ComponentArray}, A::AbstractVecOrMat)
+    ldiv!(B, Diagonal(Vector(D.diag)), A)
+end


### PR DESCRIPTION
This fixes https://github.com/SciML/ComponentArrays.jl/issues/287 by just making sure to fallback to standard BLAS routines.