### PR TITLE
Add reshape back

### DIFF
--- a/src/array_interface.jl
+++ b/src/array_interface.jl
@@ -10,6 +10,8 @@ Base.axes(x::ComponentArray) = CombinedAxis.(getaxes(x), axes(getdata(x)))
 
 Base.reinterpret(::Type{T}, x::ComponentArray, args...) where T = ComponentArray(reinterpret(T, getdata(x), args...), getaxes(x))
 
+Base.reshape(A::AbstractArray, axs::Tuple{CombinedAxis, Vararg{CombinedAxis}}) = reshape(A, _array_axis.(axs))
+
 ArrayInterface.indices_do_not_alias(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes} = ArrayInterface.indices_do_not_alias(A)
 ArrayInterface.instances_do_not_alias(::Type{ComponentArray{T,N,A,Axes}}) where {T,N,A,Axes} = ArrayInterface.instances_do_not_alias(A)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,10 +290,9 @@ end
     @test ca[Not(2:3)] == getdata(ca)[Not(2:3)]
 
     # Issue #123
-    # We had to revert this because there is no way to work around
-    # OffsetArrays' type piracy without introducing type piracy
-    # ourselves because `() isa Tuple{N, <:CombinedAxis} where {N}`
-    # @test reshape(a, axes(ca)...) isa Vector{Float64}
+    @test reshape(a, axes(ca)...) isa Vector{Float64}
+    @teset reshape(ca, axes(ca)) === ca
+    @teset reshape(ca, axes(ca)...) === ca
 
     # Issue #248: Indexing ComponentMatrix with FlatAxis components
     @test cmat3[:a, :a] == cmat3check[1, 1]
@@ -305,8 +304,6 @@ end
     @test cmat3[:c, :a] == reshape(cmat3check[6:11, 1], 3, 2)
     @test cmat3[:c, :b] == reshape(cmat3check[6:11, 2:5], 3, 2, 4)
     @test cmat3[:c, :c] == reshape(cmat3check[6:11, 6:11], 3, 2, 3, 2)
-
-    @test_broken reshape(a, axes(ca)...) isa Vector{Float64}
 
     # Issue #265: Multi-symbol indexing with matrix components
     @test ca2.c[[:a, :b]].b isa AbstractMatrix


### PR DESCRIPTION
In https://github.com/SciML/ComponentArrays.jl/commit/b81c7bc2d39f7a61e12b4db1dc7f0d35bf26cfc8 a reshape method very similar to this got added. This was piracy for the case that `axs` was an empty tuple. This was reported in #193, and this PR implements the [original suggestion](https://github.com/SciML/ComponentArrays.jl/issues/193#issuecomment-1488781163). Instead in #194 the reshape method was removed entirely since it seemed to serve no purpose other that avoiding issues with OffsetArrays.

Now I am running into

```
MethodError: no method matching reshape(::Vector{Int64}, ::Tuple{ComponentArrays.CombinedAxis{ComponentArrays.Axis{…}, Base.OneTo{…}}})
```

Being triggered from: https://github.com/JuliaDiff/FiniteDiff.jl/blob/a7eca2d4b73c4de12140d89df7621fcc90d29190/src/jacobians.jl#L422

So now we can reshape onto our own axes:

```julia
using ComponentArrays
cv = ComponentVector(; a = [1, 2], b = [3, 4, 5])
reshape(cv, axes(cv))  # -> ComponentVector{Int64}(a = [1, 2], b = [3, 4, 5])
```
