### PR TITLE
Fix CombinedAxis fallback reshape on AbstractArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.24"
+version = "0.15.25"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -255,6 +255,10 @@ function maybe_reshape(data, axs::AbstractAxis...)
     return reshape(data, shapes)
 end
 
+function Base.reshape(parent::AbstractArray, dims::ComponentArrays.CombinedAxis...)
+    reshape(parent, getfield.(dims, :array_axis))
+end
+
 # Recurse through nested ViewAxis types to find the last index
 last_index(x) = last(x)
 last_index(x::ViewAxis) = last_index(viewindex(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,7 +306,10 @@ end
     @test cmat3[:c, :b] == reshape(cmat3check[6:11, 2:5], 3, 2, 4)
     @test cmat3[:c, :c] == reshape(cmat3check[6:11, 6:11], 3, 2, 3, 2)
 
-    @test_broken reshape(a, axes(ca)...) isa Vector{Float64}
+    # https://discourse.julialang.org/t/no-method-error-reshape-when-solving-ode-with-componentarrays-jl/126342
+    x = ComponentVector(x=1.0, y=0.0, z=0.0)
+    @test reshape(x, axes(x)...) isa ComponentVector
+    @test reshape(a, axes(ca)...) isa Vector{Float64}
 
     # Issue #265: Multi-symbol indexing with matrix components
     @test ca2.c[[:a, :b]].b isa AbstractMatrix


### PR DESCRIPTION
Fixes https://discourse.julialang.org/t/no-method-error-reshape-when-solving-ode-with-componentarrays-jl/126342
