### PR TITLE
Preserve `ShapedAxis` components during `vcat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.26"
+version = "0.15.27"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/axis.jl
+++ b/src/axis.jl
@@ -163,7 +163,7 @@ reindex(i, offset) = i .+ offset
 reindex(ax::FlatAxis, _) = ax
 reindex(ax::Axis, offset) = Axis(map(x->reindex(x, offset), indexmap(ax)))
 reindex(ax::ViewAxis, offset) = ViewAxis(viewindex(ax) .+ offset, indexmap(ax))
-function reindex(ax::ViewAxis{OldInds,IdxMap,Ax}, offset) where {OldInds,IdxMap,Ax<:Shaped1DAxis} 
+function reindex(ax::ViewAxis{OldInds,IdxMap,Ax}, offset) where {OldInds,IdxMap,Ax<:Union{Shaped1DAxis,ShapedAxis}}
     NewInds = viewindex(ax) .+ offset
     return ViewAxis(NewInds, Ax())
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -852,6 +852,19 @@ end
         @test all(Xstack4_dcolon[:b, :, :] .== Xstack4_noca_dcolon[2:3, :, :])
     end
 
+    # Test that we maintain higher-order components during vcat.
+    x = ComponentVector(a=rand(Float64, 2, 3, 4), b=rand(Float64, 4, 3, 2))
+    y = ComponentVector(c=rand(Float64, 3, 4, 2), d=rand(Float64, 3, 2, 4))
+    xy = vcat(x, y)
+    @test size(xy.a) == size(x.a)
+    @test size(xy.b) == size(x.b)
+    @test size(xy.c) == size(y.c)
+    @test size(xy.d) == size(y.d)
+    @test all(xy.a .≈ x.a)
+    @test all(xy.b .≈ x.b)
+    @test all(xy.c .≈ y.c)
+    @test all(xy.d .≈ y.d)
+
     # Test fix https://github.com/Deltares/Ribasim/issues/2028
     a = range(0.0, 1.0, length=0) |> collect
     b = range(0.0, 1.0; length=2) |> collect


### PR DESCRIPTION
## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context
Currently when calling `vcat` with two `ComponentVector`s, all multi-dimensional components of the *second* argument are flattened:

```
julia> x = ComponentVector(a=rand(Float64, 2, 3, 4), b=rand(Float64, 4, 3, 2))
julia> y = ComponentVector(c=rand(Float64, 3, 4, 2), d=rand(Float64, 3, 2, 4))
julia> xy = vcat(x, y)

julia> size(xy.a)
(2, 3, 4)

julia> size(xy.b)
(4, 3, 2)

julia> size(xy.c)
(24,)

julia> size(xy.d)
(24,)

julia> 
```

This PR fixes that.

