### PR TITLE
Implementes structured update

### DIFF
--- a/src/ComponentArrays.jl
+++ b/src/ComponentArrays.jl
@@ -21,6 +21,7 @@ export AbstractAxis, Axis, PartitionedAxis, ShapedAxis, Shaped1DAxis, ViewAxis, 
 
 include("componentarray.jl")
 export ComponentArray, ComponentVector, ComponentMatrix, getaxes, getdata, valkeys
+export update_component_array
 
 include("componentindex.jl")
 export KeepIndex

--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -360,3 +360,48 @@ julia> sum(prod(ca[k]) for k in valkeys(ca))
     return :($k)
 end
 valkeys(ca::ComponentVector) = valkeys(getaxes(ca)[1])
+
+"""
+    update_component_array(default::ComponentArray{T}, update::ComponentArray) where {T}
+
+Update a ComponentArray with values from another ComponentArray while preserving structure and type stability.
+Only matching entries are updated, allowing for partial updates of nested structures.
+
+# Arguments
+- `default::ComponentArray{T}`: The ComponentArray to update, serving as both template and target
+- `update::ComponentArray`: The ComponentArray containing the new values
+
+# Returns
+- A new ComponentArray with the same type and structure as `default`, updated with values from `update`
+
+# Example
+```julia
+default = ComponentArray(sig = (mu = 1.0, sigma = 2.0), bg = 3.0)
+update = ComponentArray(sig = (mu = 1.1,), bg = 3.3)
+result = update_component_array(default, update)
+# result.sig.mu == 1.1
+# result.sig.sigma == 2.0
+# result.bg == 3.3
+```
+"""
+function update_component_array(default::ComponentArray{T}, update::ComponentArray) where {T}
+    result = copy(default)
+
+    # Update matching fields using ComponentArray's natural indexing
+    for key in propertynames(update)
+        if hasproperty(default, key)
+            update_val = update[key]
+            default_val = default[key]
+
+            if default_val isa ComponentArray && update_val isa ComponentArray
+                # Recursively update nested ComponentArrays
+                result[key] = update_component_array(default_val, update_val)
+            else
+                # Direct update for leaf values
+                result[key] = update_val
+            end
+        end
+    end
+
+    return result
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -942,3 +942,7 @@ end
 @testset "Reactant" begin
     include("reactant_tests.jl")
 end
+
+@testset "ComponentArrays" begin
+    include("update_tests.jl")
+end

--- a/test/update_tests.jl
+++ b/test/update_tests.jl
@@ -1,0 +1,54 @@
+using ComponentArrays
+using Test
+
+@testset "ComponentArray Update" begin
+    # Test 1: Basic update
+    default = ComponentArray(sig = (mu = 1.0, sigma = 2.0), bg = 3.0)
+    update = ComponentArray(sig = (mu = 1.1,), bg = 3.3)
+
+    result = update_component_array(default, update)
+
+    @test result.sig.mu ≈ 1.1
+    @test result.sig.sigma ≈ 2.0
+    @test result.bg ≈ 3.3
+
+    # Test 2: Structure preservation
+    @test typeof(result) == typeof(default)
+    @test getfield(result, :axes) == getfield(default, :axes)
+
+    # Test 3: Deep nested update
+    deep_default = ComponentArray(
+        outer = (
+            inner = (x = 1.0, y = 2.0),
+            other = 3.0,
+        ),
+        top = 4.0,
+    )
+
+    deep_update = ComponentArray(
+        outer = (
+            inner = (x = 10.0,),
+        ),
+    )
+
+    deep_result = update_component_array(deep_default, deep_update)
+
+    @test deep_result.outer.inner.x ≈ 10.0
+    @test deep_result.outer.inner.y ≈ 2.0
+    @test deep_result.outer.other ≈ 3.0
+    @test deep_result.top ≈ 4.0
+
+    # Test 4: Non-existing field update
+    nonexist_update = ComponentArray(
+        sig = (mu = 1.1,),
+        nonexistent = 42.0,  # This field doesn't exist in default
+    )
+    result_nonexist = update_component_array(default, nonexist_update)
+
+    # Should preserve structure and only update existing fields
+    @test result_nonexist.sig.mu ≈ 1.1
+    @test result_nonexist.sig.sigma ≈ 2.0
+    @test !hasproperty(result_nonexist, :nonexistent)
+    @test typeof(result_nonexist) == typeof(default)
+    @test getfield(result_nonexist, :axes) == getfield(default, :axes)
+end


### PR DESCRIPTION
Closes #303 

This PR adds `update_component_array`, a utility function that enables an update to `ComponentArray` values while maintaining type and structure.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
