### PR TITLE
Remove outdated Julia version checks

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -37,9 +37,6 @@ _print_type_short(io, ::Type{<:ComponentArray{T,N,<:SubArray}}; color=:normal) w
 _print_type_short(io, ::Type{<:ComponentArray{T,1,<:SubArray}}; color=:normal) where {T} = printstyled(io, "ComponentVector{$T,SubArray...}"; color=color)
 _print_type_short(io, ::Type{<:ComponentArray{T,2,<:SubArray}}; color=:normal) where {T} = printstyled(io, "ComponentMatrix{$T,SubArray...}"; color=color)
 
-@static if v"1.6" ≤ VERSION < v"1.8"
-    Base.print_type_stacktrace(io, CA::Type{<:ComponentArray}; color=:normal) = _print_type_short(io, CA; color=color)
-end
 
 function Base.show(io::IO, x::ComponentVector)
     print(io, "(")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -726,7 +726,7 @@ end
     @test ndims(dropdims(ones(1,1), dims=(1,2))) == 0
     @test reshape([1]) == fill(1, ())
 
-    if VERSION >= v"1.9"
+    # Tests for stack function (introduced in Julia 1.9, always available in Julia 1.10+)
         # `stack` was introduced in Julia 1.9
         # Issue #254
         x = ComponentVector(a=[1, 2])
@@ -851,7 +851,6 @@ end
         @test all(Xstack4_dcolon .== Xstack4_noca_dcolon)
         @test all(Xstack4_dcolon[:a, :, :] .== Xstack4_noca_dcolon[1, :, :])
         @test all(Xstack4_dcolon[:b, :, :] .== Xstack4_noca_dcolon[2:3, :, :])
-    end
 
     # Test that we maintain higher-order components during vcat.
     x = ComponentVector(a=rand(Float64, 2, 3, 4), b=rand(Float64, 4, 3, 2))


### PR DESCRIPTION
## Summary
- Removed version checks for Julia < 1.10 since the package now requires Julia 1.10 as minimum
- Removed `VERSION >= v"1.9"` check in test/runtests.jl 
- Removed `v"1.6" ≤ VERSION < v"1.8"` check in src/show.jl

## Details
Since ComponentArrays.jl now requires Julia 1.10 as the minimum version (as specified in Project.toml), version checks for older Julia versions are no longer necessary. This PR removes these outdated checks to simplify the codebase.

The current LTS version is Julia 1.10, so all code that was conditionally included for Julia 1.9+ is now always available.

🤖 Generated with [Claude Code](https://claude.ai/code)