### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/componentarray.jl
+++ b/src/componentarray.jl
@@ -307,10 +307,10 @@ function make_idx(data, nt::Union{NamedTuple, AbstractDict}, last_val)
     kvs = (;
         (
             k => begin
-                    inds = make_idx(data, v, lv[])[2]
-                    lv[] = last_index(inds)
-                    inds
-                end
+                inds = make_idx(data, v, lv[])[2]
+                lv[] = last_index(inds)
+                inds
+            end
                 for (k, v) in pairs(nt)
         )...,
     )


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `89fb695b45c7`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos src/componentarray.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total      Time
QA/qa.jl      |   31     31  18m29.7s
Testing ComponentArrays tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Core/uncategorized_issues_tests.jl | 77 pass, 77 total
Core/utilities_tests.jl | 4 pass, 4 total
Testing ComponentArrays tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
