### PR TITLE
Make 32-bit Core lane non-blocking (BFloat16s LLVM)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,11 +1,13 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
+# BFloat16s/NNlib/Tracker hit LLVM "soft promote" errors on i686 Julia.
 ["Core 32-bit"]
 group = "Core"
 versions = ["1"]
 os = ["ubuntu-latest"]
 arch = "x86"
+continue_on_error = true
 
 [Autodiff]
 versions = ["lts", "1", "pre"]


### PR DESCRIPTION
## Summary
- Post-merge x86 CI fails precompiling Tracker→NNlib→BFloat16s on i686 (`LLVM ERROR: Do not know how to soft promote this operator's result!`).
- Mark `["Core 32-bit"]` with `continue_on_error = true` so the lane stays visible without blocking the default branch.

## Test plan
- [ ] x86 job still runs
- [ ] Other CI groups remain required

Made with [Cursor](https://cursor.com)