### PR TITLE
Keep 32-bit Core lane hard-failing

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,13 +1,12 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
-# BFloat16s/NNlib/Tracker hit LLVM "soft promote" errors on i686 Julia.
+# Hard-failing 32-bit lane (BFloat16s/NNlib/Tracker may still hit LLVM soft-promote on i686).
 ["Core 32-bit"]
 group = "Core"
 versions = ["1"]
 os = ["ubuntu-latest"]
 arch = "x86"
-continue_on_error = true
 
 [Autodiff]
 versions = ["lts", "1", "pre"]


### PR DESCRIPTION
## Summary
- Remove `continue_on_error = true` from the `arch = \"x86\"` Core lane
- Aligns with org policy from SciML/DASSL.jl#118 / SciML/ComponentArrays.jl#417 discussion: keep 32-bit failures visible until fixed

## Test plan
- [ ] x86 Core job still schedules
- [ ] Failures (e.g. BFloat16s LLVM soft-promote) fail the workflow rather than soft-pass


Made with [Cursor](https://cursor.com)