### PR TITLE
Drop Tracker from Core tests; keep it in Autodiff

### DIFF
--- a/test/Autodiff/autodiff_tests.jl
+++ b/test/Autodiff/autodiff_tests.jl
@@ -129,6 +129,17 @@ end
     @test eltype(getdata(ps_data)) <: Float64
 end
 
+@testset "Tracker convert" begin
+    nested = ComponentArray(
+        a = 100.0,
+        b = [4.0, 1.3],
+        c = (a = (a = 1.0, b = [1.0, 4.4]), b = [0.4, 2.0, 1.0, 45.0]),
+    )
+    tr = Tracker.param(nested)
+    converted = convert(typeof(nested), tr)
+    @test converted.a == nested.a
+end
+
 @testset "ArrayInterface restructure TrackedArray" begin
     ps = ComponentArray(; a = rand(2), b = (; c = rand(2)))
     ps_tracked = Tracker.param(ps)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -12,7 +12,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
@@ -28,5 +27,4 @@ SafeTestsets = "0.0.1, 0.1"
 SciMLTesting = "2.4"
 StaticArrays = "1.9.18"
 Test = "1"
-Tracker = "0.2.38"
 Unitful = "1.28.0"

--- a/test/convert_tests.jl
+++ b/test/convert_tests.jl
@@ -8,7 +8,3 @@ include("shared/test_setup.jl")
 
 @test convert(Array, ca) == getdata(ca)
 @test convert(Matrix{Float32}, cmat) isa Matrix{Float32}
-
-tr = Tracker.param(ca)
-ca_ = convert(typeof(ca), tr)
-@test ca_.a == ca.a

--- a/test/shared/test_setup.jl
+++ b/test/shared/test_setup.jl
@@ -1,7 +1,6 @@
 using ComponentArrays
 using BenchmarkTools
 using ForwardDiff
-using Tracker
 using InvertedIndices
 using LabelledArrays
 using LinearAlgebra

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,7 +1,6 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
-# Hard-failing 32-bit lane (BFloat16s/NNlib/Tracker may still hit LLVM soft-promote on i686).
 ["Core 32-bit"]
 group = "Core"
 versions = ["1"]


### PR DESCRIPTION
## Summary

Tracker is no longer a Core test dependency. The `convert(Tracker.param(ca))` coverage moves to the Autodiff group, which already owns Tracker.

Core previously instantiated Tracker → NNlib → BFloat16s. On i686 Julia 1.12 that stack LLVM-aborts while compiling `sitofp Int64 → BFloat16` (`LLVM ERROR: Do not know how to soft promote this operator's result!`). That is why the 32-bit Core lane could not even start. Autodiff still exercises Tracker, including `param`/`data`, `gradient`, `ArrayInterface.restructure`, and now convert.

Also drop the now-stale BFloat16s/Tracker comment on `["Core 32-bit"]` (the lane stays hard-failing, as in #418).

**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Verification

`GROUP=Core julia --project=. -e 'using Pkg; Pkg.test()'` (x86_64, 1.12.4): **passed**. Core test env has no Tracker / NNlib / BFloat16s. `Core/convert_tests.jl` 7 pass (the Tracker convert assertion moved).

`GROUP=Autodiff julia --project=. -e 'using Pkg; Pkg.test()'` (x86_64, 1.12.4): **passed**, `Autodiff/autodiff_tests.jl` 69 pass.

i686 Julia 1.12.7 `GROUP=Core`: precompile succeeds (85 deps, no BFloat16s). Tests then fail in `axpy_axpby_tests.jl:30` on a 1-ULP `==` vs OpenBLAS `axpby!` (`2.2218324568639782` vs `2.221832456863978`). That is a separate 32-bit BLAS rounding issue, not Tracker. Not changed here.

Not run: QA, GPU, Downstream, Reactant, docs.

## Links

- https://github.com/SciML/ComponentArrays.jl/pull/416
- https://github.com/SciML/ComponentArrays.jl/pull/418
- https://github.com/SciML/ComponentArrays.jl/actions/runs/34130535289

🤖 Generated with Grok Build TUI (model: grok-4.6)
Agent-Session: local session 01a07c62-9594-75e1-9f42-3faabb3d6cf2 (transcript: `/home/crackauc/.grok/sessions/%2Fhome%2Fcrackauc%2Fsandbox%2Ftmp_20260907_120012_92362/01a07c62-9594-75e1-9f42-3faabb3d6cf2`)