### PR TITLE
Fix Core i686 tests: BLAS axpby ULP and Int width

### DIFF
--- a/test/axpy_axpby_tests.jl
+++ b/test/axpy_axpby_tests.jl
@@ -1,5 +1,8 @@
 include("shared/test_setup.jl")
 
+# Numeric checks compare against LinearAlgebra on the parent arrays. Broadcast
+# `α .* x .+ β .* y` can differ from BLAS axpby! by 1 ULP on i686.
+
 y = ComponentArray(a = rand(4), b = rand(4))
 x = ComponentArray(a = rand(4), b = rand(4))
 ydata = copy(getdata(y))
@@ -8,13 +11,13 @@ ystorage = getdata(y)
 result = axpy!(2, x, y)
 @test result === y
 @test getdata(result) === ystorage
-@test getdata(y) == 2 .* getdata(x) .+ ydata
+@test getdata(y) == axpy!(2, getdata(x), ydata)
 
 previous = copy(getdata(y))
 result = axpy!(2, x, result)
 @test result === y
 @test getdata(result) === ystorage
-@test getdata(y) == 2 .* getdata(x) .+ previous
+@test getdata(y) == axpy!(2, getdata(x), previous)
 
 x = ComponentArray(a = rand(4), c = rand(4))
 @test_throws ArgumentError axpy!(2, x, y)
@@ -27,13 +30,13 @@ ystorage = getdata(y)
 result = axpby!(2, x, 3, y)
 @test result === y
 @test getdata(result) === ystorage
-@test getdata(y) == 2 .* getdata(x) .+ 3 .* ydata
+@test getdata(y) == axpby!(2, getdata(x), 3, ydata)
 
 previous = copy(getdata(y))
 result = axpby!(1, x, 1, result)
 @test result === y
 @test getdata(result) === ystorage
-@test getdata(y) == getdata(x) .+ previous
+@test getdata(y) == axpby!(1, getdata(x), 1, previous)
 
 x = ComponentArray(a = rand(4), c = rand(4))
 @test_throws ArgumentError axpby!(2, x, 3, y)

--- a/test/construction_tests.jl
+++ b/test/construction_tests.jl
@@ -55,10 +55,10 @@ temp3 = ComponentArray(temp2; e = (a = 20, b = [2 4; 1 4]))
 
 # Issue #18
 temp_miss = ComponentArray(a = missing, b = [2, 1, 4, 5], c = [1, 2, 3])
-@test eltype(temp_miss) == Union{Int64, Missing}
+@test eltype(temp_miss) == Union{Int, Missing}
 @test temp_miss.a === missing
 temp_noth = ComponentArray(a = nothing, b = [2, 1, 4, 5], c = [1, 2, 3])
-@test eltype(temp_noth) == Union{Int64, Nothing}
+@test eltype(temp_noth) == Union{Int, Nothing}
 @test temp_noth.a === nothing
 
 # Issue #61


### PR DESCRIPTION
## Summary

After #419 dropped Tracker from Core, the i686 lane actually runs Core tests. Two of those tests were 64-bit-only:

1. `axpby!` is implemented as `axpby!(α, getdata(x), β, getdata(y))`. The tests compared that to broadcast `2 .* x .+ 3 .* y`, which differs from OpenBLAS by 1 ULP on i686. Compare against LinearAlgebra on the parent arrays instead (the actual wrapper contract). Identity/`===` checks are unchanged.
2. `ComponentArray(a = missing, b = [2, 1, 4, 5], ...)` promotes integer literals to `Int`, which is `Int32` on 32-bit. The tests hardcoded `Union{Int64, Missing/Nothing}`. Use `Int`.

**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Fail-before / pass-after

i686 Julia 1.12.7, unfixed `test/axpy_axpby_tests.jl:30`:

```
Test Failed
  Expression: getdata(y) == 2 .* getdata(x) .+ 3 .* ydata
   Evaluated: [..., 3.3541565563827733, ...] == [..., 3.354156556382773, ...]
```

Same machine after this change: `ALL AXPY TESTS PASSED`. Full `GROUP=Core` on i686 1.12.7: **passed** (axpy 14/14, construction 69/69, all Core files green).

`GROUP=Core` x86_64 1.12: **passed** (axpy 14/14).

CI of #419: https://github.com/SciML/ComponentArrays.jl/actions/runs/34150296278/job/101862665789 (same axpby `==` failure).

Not run: Autodiff, QA, GPU, Downstream, Reactant, docs.

## Links

- https://github.com/SciML/ComponentArrays.jl/pull/419
- https://github.com/SciML/ComponentArrays.jl/actions/runs/34150296278/job/101862665789

🤖 Generated with Grok Build TUI (model: grok-4.6)
Agent-Session: local session 01a07c62-9594-75e1-9f42-3faabb3d6cf2 (transcript: `/home/crackauc/.grok/sessions/%2Fhome%2Fcrackauc%2Fsandbox%2Ftmp_20260907_120012_92362/01a07c62-9594-75e1-9f42-3faabb3d6cf2`)