### PR TITLE
Handle raw `Array` cotangents into `FlatComponentArray` `fdata`

### DIFF
--- a/ext/ComponentArraysMooncakeExt.jl
+++ b/ext/ComponentArraysMooncakeExt.jl
@@ -314,10 +314,13 @@ function Mooncake.increment_and_get_rdata!(f::P, ::Mooncake.NoRData, t::P) where
 end
 
 # Bare Array cotangent into the new FlatComponentArray fdata -- mirrors case (a)
-# above, for the native tangent-type shape instead of the old FData wrapper.
+# above, for the native tangent-type shape instead of the old FData wrapper. N is
+# pinned to match between f and t: a dimensionality mismatch (e.g. a Vector cotangent
+# for a ComponentMatrix fdata) must fail to dispatch here rather than silently
+# broadcast against an unrelated shape.
 function Mooncake.increment_and_get_rdata!(
-        f::P, ::Mooncake.NoRData, t::Array{T},
-    ) where {T <: _FloatLike, P <: FlatComponentArray{T}}
+        f::P, ::Mooncake.NoRData, t::Array{T, N},
+    ) where {T <: _FloatLike, N, P <: FlatComponentArray{T, N}}
     getdata(f) .+= t
     return Mooncake.NoRData()
 end

--- a/ext/ComponentArraysMooncakeExt.jl
+++ b/ext/ComponentArraysMooncakeExt.jl
@@ -313,6 +313,15 @@ function Mooncake.increment_and_get_rdata!(f::P, ::Mooncake.NoRData, t::P) where
     return Mooncake.NoRData()
 end
 
+# Bare Array cotangent into the new FlatComponentArray fdata -- mirrors case (a)
+# above, for the native tangent-type shape instead of the old FData wrapper.
+function Mooncake.increment_and_get_rdata!(
+        f::P, ::Mooncake.NoRData, t::Array{T},
+    ) where {T <: _FloatLike, P <: FlatComponentArray{T}}
+    getdata(f) .+= t
+    return Mooncake.NoRData()
+end
+
 function Mooncake.__verify_fdata_value(::IdDict{Any, Nothing}, p::FlatComponentArray, f::FlatComponentArray)
     if size(p) != size(f)
         throw(Mooncake.InvalidFDataException("p has size $(size(p)) but f has size $(size(f))"))

--- a/test/Autodiff/autodiff_tests.jl
+++ b/test/Autodiff/autodiff_tests.jl
@@ -214,6 +214,26 @@ end
         @test getdata(g[2]) ≈ [2.0, 4.0, 6.0, 8.0]
     end
 
+    # (c) Raw Array cotangent (not ComponentArray-wrapped) against a flat-Array-backed
+    #     CV fdata — the shape a plain rrule returns when it's unaware of ComponentArrays.
+    sum_abs2_rawgrad(x::AbstractArray) = sum(abs2, x)
+    function ChainRulesCore.rrule(::typeof(sum_abs2_rawgrad), x::ComponentVector)
+        y = sum_abs2_rawgrad(x)
+        sum_abs2_rawgrad_pb(Δy) = (ChainRulesCore.NoTangent(), 2 .* Δy .* getdata(x))
+        return y, sum_abs2_rawgrad_pb
+    end
+    Mooncake.@from_rrule(
+        Mooncake.DefaultCtx,
+        Tuple{typeof(sum_abs2_rawgrad), ComponentVector{Float64, Vector{Float64}}},
+    )
+    let
+        v = ComponentArray(a = 1.0, b = 2.0, c = 3.0)
+        cache = Mooncake.prepare_gradient_cache(sum_abs2_rawgrad, v)
+        val, g = Mooncake.value_and_gradient!!(cache, sum_abs2_rawgrad, v)
+        @test val ≈ 14.0
+        @test getdata(g[2]) ≈ [2.0, 4.0, 6.0]
+    end
+
     @test Mooncake.friendly_tangent_cache(flat) isa
         Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}
 

--- a/test/Autodiff/autodiff_tests.jl
+++ b/test/Autodiff/autodiff_tests.jl
@@ -234,6 +234,47 @@ end
         @test getdata(g[2]) ≈ [2.0, 4.0, 6.0]
     end
 
+    # (d) Same as (c), but for a genuine ComponentMatrix (N=2) fdata, not just a
+    #     ComponentVector — `ComponentArray(a = <matrix>, ...)` actually produces a
+    #     ComponentVector whose fields are matrix-shaped views, so a real ComponentMatrix
+    #     needs `ComponentMatrix(data, Axis(...), Axis(...))`.
+    sum_abs2_rawgrad_mat(x::AbstractArray) = sum(abs2, x)
+    function ChainRulesCore.rrule(::typeof(sum_abs2_rawgrad_mat), x::ComponentMatrix)
+        y = sum_abs2_rawgrad_mat(x)
+        pb(Δy) = (ChainRulesCore.NoTangent(), 2 .* Δy .* getdata(x))
+        return y, pb
+    end
+    Mooncake.@from_rrule(
+        Mooncake.DefaultCtx,
+        Tuple{typeof(sum_abs2_rawgrad_mat), ComponentMatrix{Float64, Matrix{Float64}}},
+    )
+    let
+        cm = ComponentMatrix(Matrix(reshape(1.0:6.0, 2, 3)), Axis(r = 1:2), Axis(c = 1:3))
+        cache = Mooncake.prepare_gradient_cache(sum_abs2_rawgrad_mat, cm)
+        val, g = Mooncake.value_and_gradient!!(cache, sum_abs2_rawgrad_mat, cm)
+        @test val ≈ sum(abs2, getdata(cm))
+        @test getdata(g[2]) ≈ 2 .* getdata(cm)
+    end
+
+    # (e) A cotangent whose dimensionality doesn't match fdata's (e.g. a Vector cotangent
+    #     for a ComponentMatrix fdata) must fail loudly rather than silently broadcast
+    #     against the wrong shape (a length-matching Vector can broadcast validly-but-
+    #     wrongly against a same-length-first-dimension Matrix).
+    sum_abs2_badshape(x::AbstractArray) = sum(abs2, x)
+    function ChainRulesCore.rrule(::typeof(sum_abs2_badshape), x::ComponentMatrix)
+        y = sum_abs2_badshape(x)
+        pb(Δy) = (ChainRulesCore.NoTangent(), ones(size(getdata(x), 1)))  # wrong shape
+        return y, pb
+    end
+    Mooncake.@from_rrule(
+        Mooncake.DefaultCtx,
+        Tuple{typeof(sum_abs2_badshape), ComponentMatrix{Float64, Matrix{Float64}}},
+    )
+    let
+        cm = ComponentMatrix(Matrix(reshape(1.0:6.0, 2, 3)), Axis(r = 1:2), Axis(c = 1:3))
+        @test_throws ArgumentError Mooncake.prepare_gradient_cache(sum_abs2_badshape, cm)
+    end
+
     @test Mooncake.friendly_tangent_cache(flat) isa
         Mooncake.FriendlyTangentCache{Mooncake.AsPrimal}
 


### PR DESCRIPTION
## Summary

`increment_and_get_rdata!` only had a method for a cotangent matching fdata's own `FlatComponentArray` type. A `ChainRulesCore` rrule unaware of ComponentArrays returns a bare `Array` cotangent instead — this had no matching method and fell through to Mooncake's generic error:

```
ArgumentError: The fdata type ComponentArrays.ComponentVector{...}, rdata type Mooncake.NoRData,
and tangent type Vector{Float64} combination is not supported with @from_chainrules or @from_rrule.
```

Hit in practice via SciMLSensitivity's `InterpolatingAdjoint`/`BacksolveAdjoint` (SciML/SciMLSensitivity.jl#1427), whose pullback returns a plain gradient vector for a `ComponentVector` parameter. `GaussAdjoint`/`QuadratureAdjoint` don't hit this since their pullback already returns a compatible cotangent shape.

Adds one `increment_and_get_rdata!` method mirroring the existing raw-Array case for the old FData shape, generalized to the new native `FlatComponentArray` fdata. `N` is pinned to match between fdata and cotangent, so a dimensionality mismatch (e.g. a `Vector` cotangent for a `ComponentMatrix` fdata) fails to dispatch and errors loudly instead of silently broadcasting against the wrong shape.

Verified against ForwardDiff for a real neural-ODE gradient across `GaussAdjoint`/`InterpolatingAdjoint`/`QuadratureAdjoint`/`BacksolveAdjoint` (all four now agree to ~1e-8 relative error), and separately confirmed (via `is_primitive` plus a deliberately-wrong pullback value) that a genuine `ComponentMatrix` (N=2, constructed with `ComponentMatrix(data, Axis(...), Axis(...))`) hits this exact code path and computes the correct gradient.

## Test plan

- [x] Added regression test exercising a bare-`Array`-cotangent `@from_rrule` round-trip for `ComponentVector`
- [x] Added regression test for a genuine `ComponentMatrix` (N=2), confirmed via `is_primitive` that it actually exercises this method (not silently bypassed by native differentiation)
- [x] Added regression test confirming a dimensionality mismatch errors instead of silently broadcasting
- [x] Verified locally against a real SciMLSensitivity neural-ODE gradient (`InterpolatingAdjoint`/`BacksolveAdjoint`) vs ForwardDiff ground truth