### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,52 @@
+using ComponentArrays, BenchmarkTools
+using LinearAlgebra, StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+# =============================================================================
+# ComponentVector
+# =============================================================================
+
+SUITE["componentvector"] = BenchmarkGroup()
+
+a_data = rand(rng, 100)
+b_c = rand(rng, 50)
+b_d = rand(rng, 10, 10)
+cv = ComponentArray(a = a_data, b = (c = b_c, d = b_d))
+cv2 = ComponentArray(a = rand(rng, 100), b = (c = rand(rng, 50), d = rand(rng, 10, 10)))
+
+SUITE["componentvector"]["construct"] = @benchmarkable ComponentArray(
+    a = $a_data, b = (c = $b_c, d = $b_d)
+)
+SUITE["componentvector"]["getproperty"] = @benchmarkable $cv.b.c
+SUITE["componentvector"]["getindex_symbol"] = @benchmarkable $cv[Val(:b)]
+SUITE["componentvector"]["broadcast_add"] = @benchmarkable $cv .+ $cv2
+SUITE["componentvector"]["norm"] = @benchmarkable norm($cv)
+SUITE["componentvector"]["map"] = @benchmarkable map(sin, $cv)
+
+# =============================================================================
+# ComponentMatrix
+# =============================================================================
+
+SUITE["componentmatrix"] = BenchmarkGroup()
+
+cm_data = rand(rng, 20, 20)
+cm_ax = Axis(x = 1:10, y = 11:20)
+cm_ax2 = Axis(u = 1:10, v = 11:20)
+cm = ComponentMatrix(cm_data, cm_ax, cm_ax2)
+cv_20 = ComponentVector(x = rand(rng, 10), y = rand(rng, 10))
+
+SUITE["componentmatrix"]["construct"] = @benchmarkable ComponentMatrix(
+    $cm_data, $cm_ax, $cm_ax2
+)
+SUITE["componentmatrix"]["getindex_symbol"] = @benchmarkable $cm[Val(:x), Val(:u)]
+SUITE["componentmatrix"]["matmul"] = @benchmarkable $cm * $cv_20
+
+# =============================================================================
+# Views
+# =============================================================================
+
+SUITE["views"] = BenchmarkGroup()
+SUITE["views"]["view_axis"] = @benchmarkable $cv[Val(:b)]
+SUITE["views"]["getdata"] = @benchmarkable getdata($cv)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~7s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~7s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md