### PR TITLE
Release ComponentArrays 0.15.49

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComponentArrays"
 uuid = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 authors = ["Jonnie Diegelman <47193959+jonniedie@users.noreply.github.com>"]
-version = "0.15.48"
+version = "0.15.49"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
Bumps `ComponentArrays` 0.15.48 -> 0.15.49 (patch).

Source files changed since 0.15.48:
- `ext/ComponentArraysMooncakeExt.jl`

Commits:
- Add 32-bit Core CI lane via test_groups.toml (#415)
- Make 32-bit Core lane non-blocking (BFloat16s LLVM) (#416)
- Keep 32-bit Core lane hard-failing. (#418)
- Drop Tracker from Core tests; keep it in Autodiff (#419)
- Fix Core i686 tests: BLAS axpby ULP and Int width (#420)
- Handle raw `Array` cotangents into `FlatComponentArray` `fdata` (#421)
- Add AirspeedVelocity benchmarking CI (#422)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
